### PR TITLE
Milestone 1: Basic Menu Functionality

### DIFF
--- a/resippy.py
+++ b/resippy.py
@@ -1,5 +1,11 @@
 # resippy
 
+# Next steps:
+## Add delete function
+## Update new_recipe so that it can't add a recipe that's already in the table
+## Update update_menu so that it can't update a recipe that doesn't already exist in the table
+## Finish unittesting for Version 1
+
 import sqlite3
 import argparse
 import atexit
@@ -21,6 +27,11 @@ def new_recipe(args, **kwargs):
     Arguments:
         args(dict): Contains required argument --new and potential optional arguments --drumlin_rating, --lina_rating, --ian_rating, and --last_made.
     
+    Raises:
+        KeyError if the recipe name is missing
+        AssertionError if the last_made date is not formatted correctly
+        Database Error if something is wrong with the database
+
     Returns:
         If added properly, returns True and an empty string.
         If not added properly, returns False and the error.
@@ -68,6 +79,10 @@ def update_menu(args, **kwargs):
 
     Args:
         args (dict): Contains required argument --update_menu and potential optional arguments --drumlin_rating, --lina_rating, --ian_rating, and --last_made.
+    
+    Returns:
+        True and an empty string if the recipe is updated correctly.
+        False and the error if the last_made date is incorrect.
     """
     # Get Current Recipe Values
     cursor.execute("SELECT id FROM menu WHERE name=?", (args['update_menu'],))
@@ -92,6 +107,31 @@ def update_menu(args, **kwargs):
     query = "UPDATE menu SET {updates} WHERE {condition}".format(updates=updates_query, condition=condition_query)
 
     # Add the new recipe to the database
+    cursor.execute(query)
+    connection.commit()
+    return True, ''
+
+def delete_recipe(args, **kwargs):
+    """Deletes a recipe from the menu.
+
+    Args:
+        args (dict): Contains required argument --del_recipe and potential optional arguments --drumlin_rating, --lina_rating, --ian_rating, and --last_made.
+        
+    Returns:
+        True and an empty string if the recipe is deleted
+        False and an error string if the recipe was not found in the menu
+    """
+    # Get Recipe ID
+    cursor.execute("SELECT id FROM menu WHERE name=?", (args['del_recipe'],))
+    recipe_id = cursor.fetchall()
+    if len(recipe_id) == 1:
+        recipe_id = recipe_id[0][0]
+        id_query = "id=" + str(recipe_id)
+    elif len(recipe_id) == 0:
+        return False, "{} was not found in the menu. Please try again.".format(args['del_recipe'])
+   
+    # Delete Query
+    query = "DELETE FROM menu WHERE {id}".format(id=id_query)
     cursor.execute(query)
     connection.commit()
     return True, ''
@@ -129,6 +169,7 @@ def create_parser():
     parser.add_argument('--last_made', type=str, help="Date the recipe was last made (formatted as DD/MM/YYYY)")
     parser.add_argument('--viewmenu', action="store_true", help="View the menu.")
     parser.add_argument('--update_menu', help="Name of the recipe you would like to update in the menu")
+    parser.add_argument('--del_recipe', help="Name of the recipe you would like to delete from the menu")
     return parser
 
 def exit_handler():
@@ -150,11 +191,29 @@ if __name__ == "__main__":
             print("{} has been added to the homehold menu!".format(recipe_name))
         else:
             print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))
+    ## View Menu
     if args.viewmenu:
         view_menu(vars(args))
+    ## Update Menu
     if args.update_menu:
         updated, error = update_menu(vars(args))
         if updated:
             print("{} has been updated in the homehold menu!".format(args.update_menu))
         else:
             print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))
+    ## Delete a Recipe
+    if args.del_recipe:
+        confirm = input("{} will be permanently deleted from the homehold menu. Are you sure you would like to continue? [Y/N]  ".format(args.del_recipe))
+        deleted = False
+        while not deleted:
+            if confirm.strip().upper() == "Y":
+                deleted, error = delete_recipe(vars(args))
+                if deleted:
+                    print("{} has been deleted from the menu.".format(args.del_recipe))
+                else:
+                    print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))
+                    deleted = True
+            elif confirm.strip().upper() == "N":
+                deleted = True
+            else:
+                confirm = input("Unrecognized argument. Please enter Y or N. \n {} will be permanently deleted from the homehold menu. Are you sure you would like to continue? [Y/N]  ".format(args.del_recipe))

--- a/resippy.py
+++ b/resippy.py
@@ -27,7 +27,8 @@ def new_recipe(args, **kwargs):
     """
     # Parse argument
     try:
-        recipe_information = {k:v for k,v in args.items() if v is not None}
+        recipe_arguments = ['new', 'drumlin_rating', 'lina_rating', 'ian_rating', 'last_made']
+        recipe_information = {k:v for k,v in args.items() if v is not None and k in recipe_arguments}
         recipe_information['name'] = recipe_information.pop('new')
         if 'last_made' in recipe_information:
             valid, e, recipe_information['last_made'] = check_date(recipe_information['last_made'])
@@ -74,13 +75,15 @@ def update_menu(args, **kwargs):
     recipe_id = recipe_id[0][0]
 
     # Find new updates from args
-    potential_updates = {k:v for k, v in args.items() if v is not None}
     potential_arguments = ["drumlin_rating", "lina_rating", "ian_rating", "last_made"]
-    updates = {k:v for k, v in potential_updates.items() if k in potential_arguments}
+    updates = {k:v for k, v in args.items() if v is not None and k in potential_arguments}
+
     if "last_made" in updates:
         valid, e, updates['last_made'] = check_date(updates['last_made'])
         if not valid:
             return valid, e
+        else:
+            updates['last_made'] = '"{update}"'.format(update=updates['last_made'])
     updates_query = ""
     for update in updates.keys():
         updates_query += "{column}={new_value},".format(column=update, new_value=updates[update])
@@ -102,16 +105,15 @@ def check_date(input_date):
     """
     date_pattern = r"(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0,1,2])\/(20)\d{2}"
     try:
-        datetime.strptime(input_date, "%d/%m/%Y")
         if not re.match(date_pattern, input_date):
             raise ValueError
         else:
-            last_made = input_date.split('/')
-            formatted_date = date(int(last_made[2]), int(last_made[1]), int(last_made[0]))
+            formatted_date = datetime.strptime(input_date, "%d/%m/%Y").strftime('%Y-%m-%d')
             return True, "", formatted_date
     except ValueError:
         return False, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.', ''
 
+# I/O Functions
 def create_parser():
     """
     Creates a parser for the program.

--- a/resippy.py
+++ b/resippy.py
@@ -13,13 +13,19 @@ from datetime import date, datetime
 import re
 from tabulate import tabulate
 
-# Get sqlite3 database
-connection = sqlite3.connect('resippy.db')
-cursor = connection.cursor()
-cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating DECIMAL, ian_rating DECIMAL, lina_rating DECIMAL, last_made DATE)')
-connection.commit()
+# Database Set-Up
+def get_database():
+    """
+    Accesses the sqlite3 database.
+    """
+    # Connect to database & create cursor
+    connection = sqlite3.connect('resippy.db')
+    cursor = connection.cursor()
+    # Make tables if they do not already exist
+    cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating DECIMAL, ian_rating DECIMAL, lina_rating DECIMAL, last_made DATE, UNIQUE(id, name))')
+    connection.commit()
 
-# Add New Recipe to Database
+# Menu Functions
 def new_recipe(args, **kwargs):
     """
     Adds a new recipe to the database.
@@ -179,9 +185,12 @@ def exit_handler():
     connection.close()
 
 if __name__ == "__main__":
+    # Set up parser & exit handler
     atexit.register(exit_handler)
     parser = create_parser()
     args = parser.parse_args()
+    # Get Database
+    get_database()
     # Decide on Next Action
     ## Add new recipe
     if args.new:

--- a/resippy.py
+++ b/resippy.py
@@ -59,7 +59,6 @@ def view_menu(args, **kwargs):
     Args:
         args(dict): Contains potential optional arguments --order, --limit, and/or --filter.
     """
-
     # Get Menu
     cursor.execute("SELECT * FROM menu")
     menu = cursor.fetchall()
@@ -67,6 +66,44 @@ def view_menu(args, **kwargs):
     # Print the headings
     headers = [description[0] for description in cursor.description]
     print(tabulate(menu, headers=headers, tablefmt="grid", numalign='center'))
+
+def update_menu(args, **kwargs):
+    """Updates an entry in the menu.
+
+    Args:
+        args (dict): Contains required argument --update_menu and potential optional arguments --drumlin_rating, --lina_rating, --ian_rating, and --last_made.
+    """
+    # Get Current Recipe Values
+    cursor.execute("SELECT id FROM menu WHERE name=?", (args['update_menu'],))
+    recipe_id = cursor.fetchall()
+    recipe_id = recipe_id[0][0]
+
+    # Find new updates from args
+    potential_updates = {k:v for k, v in args.items() if v is not None}
+    potential_arguments = ["drumlin_rating", "lina_rating", "ian_rating", "last_made"]
+    updates = {k:v for k, v in potential_updates.items() if k in potential_arguments}
+    if "last_made" in updates:
+        date_pattern = r"(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0,1,2])\/(20)\d{2}"
+        try:
+            datetime.strptime(updates['last_made'], "%d/%m/%Y")
+            if not re.match(date_pattern, updates['last_made']):
+                raise ValueError
+        except ValueError:
+            return False, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.'
+        last_made = updates['last_made'].split('/')
+        updates['last_made'] = date(int(last_made[2]), int(last_made[1]), int(last_made[0]))
+    updates_query = ""
+    for update in updates.keys():
+        updates_query += "{column}={new_value},".format(column=update, new_value=updates[update])
+        updates_query = updates_query[:-1]
+    condition_query = "id={recipe_id}".format(recipe_id=recipe_id)
+    query = "UPDATE menu SET {updates} WHERE {condition}".format(updates=updates_query, condition=condition_query)
+
+    # Add the new recipe to the database
+    cursor.execute(query)
+    connection.commit()
+    return True, ''
+    
 
 def create_parser():
     """
@@ -82,6 +119,7 @@ def create_parser():
     parser.add_argument('--lina_rating', type=float, help="Lina's rating of the recipe")
     parser.add_argument('--last_made', type=str, help="Date the recipe was last made (formatted as DD/MM/YYYY)")
     parser.add_argument('--viewmenu', action="store_true", help="View the menu.")
+    parser.add_argument('--update_menu', help="Name of the recipe you would like to update in the menu")
     return parser
 
 def exit_handler():
@@ -105,4 +143,9 @@ if __name__ == "__main__":
             print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))
     if args.viewmenu:
         view_menu(vars(args))
-
+    if args.update_menu:
+        updated, error = update_menu(vars(args))
+        if updated:
+            print("{} has been updated in the homehold menu!".format(args.update_menu))
+        else:
+            print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))

--- a/resippy.py
+++ b/resippy.py
@@ -5,6 +5,7 @@ import argparse
 import atexit
 from datetime import date, datetime
 import re
+from tabulate import tabulate
 
 # Get sqlite3 database
 connection = sqlite3.connect('resippy.db')
@@ -16,11 +17,13 @@ connection.commit()
 def new_recipe(args, **kwargs):
     """
     Adds a new recipe to the database.
-    When a new recipe is made, I need to:
-        * Add it to the menu table
         
     Arguments:
-        recipe_information(dict): Information passed from the command that at the very least MUST include the recipe name. May also include drumlin_rating, lina_rating, ian_rating, and last_made values.
+        args(dict): Contains required argument --new and potential optional arguments --drumlin_rating, --lina_rating, --ian_rating, and --last_made.
+    
+    Returns:
+        If added properly, returns True and an empty string.
+        If not added properly, returns False and the error.
     """
     # Parse argument
     try:
@@ -49,9 +52,22 @@ def new_recipe(args, **kwargs):
     except Exception as e:
         return False, e
 
-args = {'new': None, 'drumlin_rating': 5, 'ian_rating': 4, 'lina_rating': 3, 'last_made': '01/11/2022'}
-new_recipe(args)
+def view_menu(args, **kwargs):
+    """
+    Prints out the menu onto the console for easy viewing.
+
+    Args:
+        args(dict): Contains potential optional arguments --order, --limit, and/or --filter.
+    """
+
+    # Get Menu
+    cursor.execute("SELECT * FROM menu")
+    menu = cursor.fetchall()
     
+    # Print the headings
+    headers = [description[0] for description in cursor.description]
+    print(tabulate(menu, headers=headers, tablefmt="grid", numalign='center'))
+
 def create_parser():
     """
     Creates a parser for the program.
@@ -65,7 +81,7 @@ def create_parser():
     parser.add_argument('--ian_rating', type=float, help="ian's rating of the recipe")
     parser.add_argument('--lina_rating', type=float, help="Lina's rating of the recipe")
     parser.add_argument('--last_made', type=str, help="Date the recipe was last made (formatted as DD/MM/YYYY)")
-
+    parser.add_argument('--viewmenu', action="store_true", help="View the menu.")
     return parser
 
 def exit_handler():
@@ -87,4 +103,6 @@ if __name__ == "__main__":
             print("{} has been added to the homehold menu!".format(recipe_name))
         else:
             print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))
+    if args.viewmenu:
+        view_menu(vars(args))
 

--- a/resippy.py
+++ b/resippy.py
@@ -3,11 +3,13 @@
 import sqlite3
 import argparse
 import atexit
+from datetime import date, datetime
+import re
 
 # Get sqlite3 database
 connection = sqlite3.connect('resippy.db')
 cursor = connection.cursor()
-cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating INT, ian_rating INT, lina_rating INT, last_made TEXT)')
+cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating DECIMAL, ian_rating DECIMAL, lina_rating DECIMAL, last_made DATE)')
 connection.commit()
 
 # Add New Recipe to Database
@@ -16,27 +18,39 @@ def new_recipe(args, **kwargs):
     Adds a new recipe to the database.
     When a new recipe is made, I need to:
         * Add it to the menu table
-        * Create a new ingredients table for it
-        * 
-
+        
     Arguments:
         recipe_information(dict): Information passed from the command that at the very least MUST include the recipe name. May also include drumlin_rating, lina_rating, ian_rating, and last_made values.
-        mode(str): One of 'manual' or 'URL'
-
     """
     # Parse argument
-    recipe_information = {k:v for k,v in args.items() if v is not None}
-    recipe_information['name'] = recipe_information.pop('new')
-    columns = ", ".join(recipe_information.keys())
-    placeholders = ", ".join(['?'] * len(recipe_information))
-    query = "INSERT INTO menu ({0}) VALUES ({1})".format(columns, placeholders)
     try:
+        recipe_information = {k:v for k,v in args.items() if v is not None}
+        recipe_information['name'] = recipe_information.pop('new')
+        if 'last_made' in recipe_information:
+            date_pattern = r"(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0,1,2])\/(20)\d{2}"
+            assert re.match(date_pattern, recipe_information['last_made']), 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.'
+            try:
+                datetime.strptime(recipe_information['last_made'], "%d/%m/%Y")
+            except ValueError:
+                pass
+            last_made = recipe_information['last_made'].split('/')
+            recipe_information['last_made'] = date(int(last_made[2]), int(last_made[1]), int(last_made[0]))
+        columns = ", ".join(recipe_information.keys())
+        placeholders = ", ".join(['?'] * len(recipe_information))
+        query = "INSERT INTO menu ({0}) VALUES ({1})".format(columns, placeholders)
         # Add the new recipe to the database
         cursor.execute(query, list(recipe_information.values()))
         connection.commit()
         return True, ''
+    except KeyError:
+        return False, 'Recipe name missing'
+    except AssertionError:
+        return False, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.'
     except Exception as e:
         return False, e
+
+args = {'new': None, 'drumlin_rating': 5, 'ian_rating': 4, 'lina_rating': 3, 'last_made': '01/11/2022'}
+new_recipe(args)
     
 def create_parser():
     """
@@ -47,10 +61,10 @@ def create_parser():
     # Menu Parsers
     ## For adding a new recipe
     parser.add_argument('--new', help="Name of the recipe you would like to add to the menu")
-    parser.add_argument('--drumlin_rating', type=int, help="Drumlin's rating of the recipe")
-    parser.add_argument('--ian_rating', type=int, help="ian's rating of the recipe")
-    parser.add_argument('--lina_rating', type=int, help="Lina's rating of the recipe")
-    parser.add_argument('--last_made', type=int, help="Date the recipe was last made")
+    parser.add_argument('--drumlin_rating', type=float, help="Drumlin's rating of the recipe")
+    parser.add_argument('--ian_rating', type=float, help="ian's rating of the recipe")
+    parser.add_argument('--lina_rating', type=float, help="Lina's rating of the recipe")
+    parser.add_argument('--last_made', type=str, help="Date the recipe was last made (formatted as DD/MM/YYYY)")
 
     return parser
 
@@ -72,5 +86,5 @@ if __name__ == "__main__":
         if added:
             print("{} has been added to the homehold menu!".format(recipe_name))
         else:
-            print("An error has ocurred. Please try again. \n Error Information: {error}".format(error))
+            print("An error has ocurred. Please try again. \n Error Information: {error}".format(error=error))
 

--- a/resippy.py
+++ b/resippy.py
@@ -13,14 +13,14 @@ from datetime import date, datetime
 import re
 from tabulate import tabulate
 
+connection = sqlite3.connect('resippy.db')
+cursor = connection.cursor()
+
 # Database Set-Up
-def get_database():
+def setup_database():
     """
-    Accesses the sqlite3 database.
+    Sets up the sqlite3 database.
     """
-    # Connect to database & create cursor
-    connection = sqlite3.connect('resippy.db')
-    cursor = connection.cursor()
     # Make tables if they do not already exist
     cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating DECIMAL, ian_rating DECIMAL, lina_rating DECIMAL, last_made DATE, UNIQUE(id, name))')
     connection.commit()
@@ -186,11 +186,12 @@ def exit_handler():
 
 if __name__ == "__main__":
     # Set up parser & exit handler
-    atexit.register(exit_handler)
     parser = create_parser()
     args = parser.parse_args()
     # Get Database
-    get_database()
+    setup_database()
+    # Set up exit handler
+    atexit.register(exit_handler)
     # Decide on Next Action
     ## Add new recipe
     if args.new:

--- a/resippy.py
+++ b/resippy.py
@@ -1,7 +1,6 @@
 # resippy
 
 # Next steps:
-## Update new_recipe so that it can't add a recipe that's already in the table
 ## Update update_menu so that it can't update a recipe that doesn't already exist in the table
 ## Finish unittesting for Version 1
 
@@ -95,8 +94,10 @@ def update_menu(args, **kwargs):
     # Get Current Recipe Values
     cursor.execute("SELECT id FROM menu WHERE name=?", (args['update_menu'],))
     recipe_id = cursor.fetchall()
-    recipe_id = recipe_id[0][0]
-
+    if recipe_id == 1:
+        recipe_id = recipe_id[0][0]
+    else:
+        return False, "{} was not found in the menu. If you would like to add it, please use --new.".format(args['update_menu'])
     # Find new updates from args
     potential_arguments = ["drumlin_rating", "lina_rating", "ian_rating", "last_made"]
     updates = {k:v for k, v in args.items() if v is not None and k in potential_arguments}

--- a/resippy_spec.rst
+++ b/resippy_spec.rst
@@ -1,6 +1,6 @@
-======================================
+=============================
 resippy program specification
-======================================
+=============================
 
 Description
 ===========
@@ -14,7 +14,7 @@ usage: resippy [--version] [--addnew] [--viewrecipe] [--viewmenu]
 
 Menu
 ----
--n, --new: Add a new recipe to the database. Must be followed by the recipe name. Additional optional arguments: [-drumlin_rating], [-ian_rating], [-lina_rating], [-last_made] (if these are not provided, they will be NULL in the table)
+-n, --new: Add a new recipe to the database. Must be followed by the recipe name. Additional optional arguments: [--drumlin_rating], [--ian_rating], [--lina_rating], [--last_made] (if these are not provided, they will be NULL in the table)
 --viewmenu: View the whole menu. Additional optional arguments:
 	-o, --order: 
 	-l, --limit:

--- a/resippy_spec.rst
+++ b/resippy_spec.rst
@@ -21,7 +21,7 @@ Menu
 	-f, --filter:
 -t, --toprecipes: View the menu organized by rating. Must be followed by one of "drumlin", "ian", or "lina". Additional optional arguments:
 	-l, --limit:
--u, --update: Update the menu. Must be followed by the recipe name and one of the following: [-drumlin_rating], [-ian_rating], [-lina_rating], [-last_made]
+-u, --update_menu: Update the menu. Must be followed by the recipe name and one of the following: [-drumlin_rating], [-ian_rating], [-lina_rating], [-last_made]
 -d, --delete: Delete a recipe from the menu. Must be followed by the recipe name. User will be prompted to confirm [Y/N].
 --random: Prints out a random meal from the menu. Additional arguments:
 	-f, --filter:

--- a/resippy_unittesting.py
+++ b/resippy_unittesting.py
@@ -1,13 +1,14 @@
 # resippy.py unit testing
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import sqlite3
 import os
-from resippy import new_recipe, view_menu
+from resippy import new_recipe, view_menu, setup_database, update_menu, check_date, create_parser
 import sys
 from io import StringIO
 
+# 3 tests
 class testDatabaseCreation(unittest.TestCase):
     def setUp(self):
         self.db = 'resippy_test.db'
@@ -19,8 +20,7 @@ class testDatabaseCreation(unittest.TestCase):
         os.remove(self.db)
     
     def test_table_creation(self):
-        self.cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating INT, ian_rating INT, lina_rating INT, last_made TEXT)')
-        self.connection.commit()
+        setup_database(self.cursor, self.connection)
 
         # Check if the table exists
         self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='menu'")
@@ -28,8 +28,7 @@ class testDatabaseCreation(unittest.TestCase):
         self.assertIsNotNone(result)
 
     def test_table_structure(self):
-        self.cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating INT, ian_rating INT, lina_rating INT, last_made TEXT)')
-        self.connection.commit()
+        setup_database(self.cursor, self.connection)
 
         # Check the table structure
         self.cursor.execute("PRAGMA table_info(menu)")
@@ -37,23 +36,33 @@ class testDatabaseCreation(unittest.TestCase):
         expected_columns = [
             (0, 'id', 'INTEGER', 0, None, 1),
             (1, 'name', 'TEXT', 0, None, 0),
-            (2, 'drumlin_rating', 'INT', 0, None, 0),
-            (3, 'ian_rating', 'INT', 0, None, 0),
-            (4, 'lina_rating', 'INT', 0, None, 0),
-            (5, 'last_made', 'TEXT', 0, None, 0)
+            (2, 'drumlin_rating', 'DECIMAL', 0, None, 0),
+            (3, 'ian_rating', 'DECIMAL', 0, None, 0),
+            (4, 'lina_rating', 'DECIMAL', 0, None, 0),
+            (5, 'last_made', 'DATE', 0, None, 0)
         ]
         self.assertEqual(columns, expected_columns)
 
-class testNewRecipe(unittest.TestCase):
+    def test_unique_name(self):
+        setup_database(self.cursor, self.connection)
 
+        self.cursor.execute('INSERT INTO menu (name) VALUES ("Test")')
+        self.connection.commit()
+        
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.cursor.execute('INSERT INTO menu (name) VALUES ("Test")')
+            self.connection.commit()
+
+# 8 tests
+class testNewRecipe(unittest.TestCase):
     @patch('resippy.cursor')
     @patch('resippy.connection')
-    def test_successful_addition(self, mock_connection, mock_cursor):
+    def test_full_successful_addition(self, mock_connection, mock_cursor):
         args = {'new': 'Spaghetti', 'drumlin_rating': 5, 'ian_rating': 4, 'lina_rating': 3, 'last_made': '01/11/2022'}
         success, message = new_recipe(args)
         self.assertTrue(success)
         self.assertEqual(message, '')
-        mock_cursor.execute.assert_called_once()
+        mock_cursor.execute.assert_called_once_with('INSERT INTO menu (drumlin_rating, ian_rating, lina_rating, last_made, name) VALUES (?, ?, ?, ?, ?)', [5, 4, 3, '2022-11-01', 'Spaghetti'])
         mock_connection.commit.assert_called_once()
     
     @patch('resippy.cursor')
@@ -63,7 +72,7 @@ class testNewRecipe(unittest.TestCase):
         success, message = new_recipe(args)
         self.assertTrue(success)
         self.assertEqual(message, '')
-        mock_cursor.execute.assert_called_once()
+        mock_cursor.execute.assert_called_once_with("INSERT INTO menu (name) VALUES (?)", ['Spaghetti'])
         mock_connection.commit.assert_called_once()
 
     @patch('resippy.cursor')
@@ -83,22 +92,21 @@ class testNewRecipe(unittest.TestCase):
         success, message = new_recipe(args)
         self.assertTrue(success)
         self.assertEqual(message, '')
-        mock_cursor.execute.assert_called_once()
+        mock_cursor.execute.assert_called_once_with('INSERT INTO menu (lina_rating, last_made, name) VALUES (?, ?, ?)', [3, '2022-11-01', 'Spaghetti'])
         mock_connection.commit.assert_called_once()
 
     @patch('resippy.cursor')
     @patch('resippy.connection')
     def test_database_error(self, mock_connection, mock_cursor):
-        mock_cursor.execute.side_effect = Exception("Database Error")
+        mock_cursor.execute.side_effect = sqlite3.DatabaseError("Database Error")
         args = {'new': 'Spaghetti'}
         success, message = new_recipe(args)
         self.assertFalse(success)
-        self.assertIsInstance(message, Exception)
-        self.assertEqual(str(message), "Database Error")
+        self.assertEqual(str(message), 'The database "resippy" was not found.')
 
     @patch('resippy.cursor')
     @patch('resippy.connection')
-    def test_correct_date_format(self, mock_connection, mock_cursor):
+    def test_correct_date_format_string(self, mock_connection, mock_cursor):
         args = {'new': 'Spaghetti', 'last_made': 'not right'}
         success, message = new_recipe(args)
         self.assertFalse(success)
@@ -106,7 +114,28 @@ class testNewRecipe(unittest.TestCase):
         mock_cursor.execute.assert_not_called()
         mock_connection.commit.assert_not_called()
 
-class TestViewMenu(unittest.TestCase):
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_correct_date_format_not_valid_date(self, mock_connection, mock_cursor):
+        args = {'new': 'Spaghetti', 'last_made': '32/01/2025'}
+        success, message = new_recipe(args)
+        self.assertFalse(success)
+        self.assertEqual(message, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.')
+        mock_cursor.execute.assert_not_called()
+        mock_connection.commit.assert_not_called()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_repeat_entry(self, mock_connection, mock_cursor):
+        mock_cursor.execute.side_effect = sqlite3.IntegrityError
+        success, message = new_recipe({"new":"Spaghetti"})
+        self.assertFalse(success)
+        self.assertEqual(str(message), 'Spaghetti is already in the homehold menu. If you would like to update this recipe, use --update_menu instead.')
+        mock_cursor.execute.assert_called_once()
+        mock_connection.commit.assert_not_called()
+
+# 3 tests
+class testViewMenu(unittest.TestCase):
     @patch('resippy.cursor')
     @patch('resippy.tabulate')
     def test_basic_functionality(self, mock_tabulate, mock_cursor):
@@ -152,6 +181,146 @@ class TestViewMenu(unittest.TestCase):
             tablefmt="grid",
             numalign='center'
         )
+
+# 8 tests
+class testUpdateMenu(unittest.TestCase):
+    @patch('resippy.connection')
+    @patch('resippy.cursor')
+    def test_basic_functionality(self, mock_cursor, mock_connection):
+        args = {'update_menu':"Spaghetti", "drumlin_rating":1}
+        mock_cursor.fetchall.return_value = [(1,)]
+        success, message = update_menu(args)
+        self.assertTrue(success)
+        self.assertEqual(message, "")
+        self.assertEqual(mock_cursor.execute.call_count, 2)
+        mock_connection.commit.assert_called_once()
+        
+    @patch('resippy.connection')
+    @patch('resippy.cursor')
+    def test_not_in_menu(self, mock_cursor, mock_connection):
+        args = {'update_menu':"Spaghetti", "drumlin_rating":1}
+        mock_cursor.fetchall.return_value = []
+        success, message = update_menu(args)
+        self.assertFalse(success)
+        self.assertEqual(message, "Spaghetti was not found in the menu. If you would like to add it, please use --new.")
+        mock_connection.commit.assert_not_called()
+        mock_cursor.execute.assert_called_once()
+
+    @patch('resippy.connection')
+    @patch('resippy.cursor')
+    def test_missing_additional_arguments(self, mock_cursor, mock_connection):
+        args = {'update_menu':"Spaghetti"}
+        mock_cursor.fetchall.return_value = [(1,)]
+        success, message = update_menu(args)
+        self.assertFalse(success)
+        self.assertEqual(message, "Please include the information you need to update (either a rating or a last-made date).")
+        mock_connection.commit.assert_not_called()
+        mock_cursor.execute.assert_called_once()
+        
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_missing_name(self, mock_connection, mock_cursor):
+        args = {'update_menu': None, 'drumlin_rating': 5, 'ian_rating': 4, 'lina_rating': 3, 'last_made': '01/11/2022'}
+        success, message = update_menu(args)      
+        self.assertFalse(success)  
+        self.assertEqual(message, 'Recipe name missing!')
+        mock_cursor.execute.assert_not_called()
+        mock_connection.commit.assert_not_called()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_ignores_none(self, mock_connection, mock_cursor):
+        args = {'update_menu': 'Spaghetti', 'drumlin_rating': None, 'ian_rating': None, 'lina_rating': 3, 'last_made': '01/11/2022'}
+        mock_cursor.fetchall.return_value = [(1,)]
+        success, message = update_menu(args)
+        self.assertTrue(success)
+        self.assertEqual(message, '')
+        self.assertEqual(mock_cursor.execute.call_count, 2)
+        mock_connection.commit.assert_called_once()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_database_error(self, mock_connection, mock_cursor):
+        mock_cursor.fetchall.return_value = [(1,)]
+        mock_cursor.execute.side_effect = sqlite3.DatabaseError("Database Error")
+        args = {'update_menu': 'Spaghetti', 'drumlin_rating': 5}
+        success, message = update_menu(args)
+        self.assertFalse(success)
+        self.assertEqual(str(message), 'The database "resippy" was not found.')
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_correct_date_format_string(self, mock_connection, mock_cursor):
+        args = {'update_menu': 'Spaghetti', 'last_made': 'not right'}
+        mock_cursor.fetchall.return_value = [(1,)]
+        success, message = update_menu(args)
+        self.assertFalse(success)
+        self.assertEqual(message, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.')
+        mock_cursor.execute.assert_called_once()
+        mock_connection.commit.assert_not_called()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_correct_date_format_not_valid_date(self, mock_connection, mock_cursor):
+        args = {'update_menu': 'Spaghetti', 'last_made': '32/01/2025'}
+        mock_cursor.fetchall.return_value = [(1,)]
+        success, message = update_menu(args)
+        self.assertFalse(success)
+        self.assertEqual(message, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.')
+        mock_cursor.execute.assert_called_once()
+        mock_connection.commit.assert_not_called()
+
+# 4 tests
+class testCheckDate(unittest.TestCase):
+    def test_correct_pattern(self):
+        input_date = "01/11/2022"
+        success, message, output_date = check_date(input_date)
+        self.assertTrue(success)
+        self.assertEqual(message, "")
+        self.assertEqual(output_date, "2022-11-01")
+
+    def test_not_string(self):
+        input_date = "date"
+        success, message, output_date = check_date(input_date)
+        self.assertFalse(success)
+        self.assertEqual(message, "Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.")
+        self.assertEqual(output_date, "")
+
+    def test_wrong_format(self):
+        input_date = "2022/11/01"
+        success, message, output_date = check_date(input_date)
+        self.assertFalse(success)
+        self.assertEqual(message, "Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.")
+        self.assertEqual(output_date, "")
+
+    def test_not_valid_date(self):
+        input_date = "30/02/2022"
+        success, message, output_date = check_date(input_date)
+        self.assertFalse(success)
+        self.assertEqual(message, "Date out of range for month. Please double-check last-made date, and input it as DD/MM/YYYY.")
+        self.assertEqual(output_date, "")
+
+# 3 tests
+class testCreateParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = create_parser()
+
+    def test_parser_arguments(self):
+        parsed = self.parser.parse_args(['--new', 'Spaghetti', '--drumlin_rating', '5', '--ian_rating', '5', '--lina_rating', '5', '--last_made', "2019", '--viewmenu'])
+        self.assertEqual(parsed.new, "Spaghetti")
+        self.assertEqual(parsed.drumlin_rating, 5)
+        self.assertEqual(parsed.ian_rating, 5)
+        self.assertEqual(parsed.lina_rating, 5)
+        self.assertEqual(parsed.last_made, "2019")
+        self.assertTrue(parsed.viewmenu)
+
+    def test_parser_mutually_exclusive(self):
+        with self.assertRaises(SystemExit):
+            parsed = self.parser.parse_args(['--new', 'Spaghetti', '--del_recipe', "Curry"])
+    
+    def test_parser_rating_values(self):
+        with self.assertRaises(SystemExit):
+            parsed = self.parser.parse_args(['--ian_rating', '70'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/resippy_unittesting.py
+++ b/resippy_unittesting.py
@@ -1,0 +1,109 @@
+# resippy.py unit testing
+
+import unittest
+from unittest.mock import patch, MagicMock
+import sqlite3
+import os
+from resippy import new_recipe
+
+class testDatabaseCreation(unittest.TestCase):
+    def setUp(self):
+        self.db = 'resippy_test.db'
+        self.connection = sqlite3.connect(self.db)
+        self.cursor = self.connection.cursor()  
+
+    def tearDown(self):
+        self.connection.close()
+        os.remove(self.db)
+    
+    def test_table_creation(self):
+        self.cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating INT, ian_rating INT, lina_rating INT, last_made TEXT)')
+        self.connection.commit()
+
+        # Check if the table exists
+        self.cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='menu'")
+        result = self.cursor.fetchone()
+        self.assertIsNotNone(result)
+
+    def test_table_structure(self):
+        self.cursor.execute('CREATE TABLE IF NOT EXISTS menu (id INTEGER PRIMARY KEY, name TEXT, drumlin_rating INT, ian_rating INT, lina_rating INT, last_made TEXT)')
+        self.connection.commit()
+
+        # Check the table structure
+        self.cursor.execute("PRAGMA table_info(menu)")
+        columns = self.cursor.fetchall()
+        expected_columns = [
+            (0, 'id', 'INTEGER', 0, None, 1),
+            (1, 'name', 'TEXT', 0, None, 0),
+            (2, 'drumlin_rating', 'INT', 0, None, 0),
+            (3, 'ian_rating', 'INT', 0, None, 0),
+            (4, 'lina_rating', 'INT', 0, None, 0),
+            (5, 'last_made', 'TEXT', 0, None, 0)
+        ]
+        self.assertEqual(columns, expected_columns)
+
+class testNewRecipe(unittest.TestCase):
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_successful_addition(self, mock_connection, mock_cursor):
+        args = {'new': 'Spaghetti', 'drumlin_rating': 5, 'ian_rating': 4, 'lina_rating': 3, 'last_made': '01/11/2022'}
+        success, message = new_recipe(args)
+        self.assertTrue(success)
+        self.assertEqual(message, '')
+        mock_cursor.execute.assert_called_once()
+        mock_connection.commit.assert_called_once()
+    
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_minimal_addition(self, mock_connection, mock_cursor):
+        args = {'new': 'Spaghetti'}
+        success, message = new_recipe(args)
+        self.assertTrue(success)
+        self.assertEqual(message, '')
+        mock_cursor.execute.assert_called_once()
+        mock_connection.commit.assert_called_once()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_missing_name(self, mock_connection, mock_cursor):
+        args = {'new': None, 'drumlin_rating': 5, 'ian_rating': 4, 'lina_rating': 3, 'last_made': '01/11/2022'}
+        success, message = new_recipe(args)      
+        self.assertFalse(success)  
+        self.assertEqual(message, 'Recipe name missing')
+        mock_cursor.execute.assert_not_called()
+        mock_connection.commit.assert_not_called()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_ignores_none(self, mock_connection, mock_cursor):
+        args = {'new': 'Spaghetti', 'drumlin_rating': None, 'ian_rating': None, 'lina_rating': 3, 'last_made': '01/11/2022'}
+        success, message = new_recipe(args)
+        self.assertTrue(success)
+        self.assertEqual(message, '')
+        mock_cursor.execute.assert_called_once()
+        mock_connection.commit.assert_called_once()
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_database_error(self, mock_connection, mock_cursor):
+        mock_cursor.execute.side_effect = Exception("Database Error")
+        args = {'new': 'Spaghetti'}
+        success, message = new_recipe(args)
+        self.assertFalse(success)
+        self.assertIsInstance(message, Exception)
+        self.assertEqual(str(message), "Database Error")
+
+    @patch('resippy.cursor')
+    @patch('resippy.connection')
+    def test_correct_date_format(self, mock_connection, mock_cursor):
+        args = {'new': 'Spaghetti', 'last_made': 'not right'}
+        success, message = new_recipe(args)
+        self.assertFalse(success)
+        self.assertEqual(message, 'Incorrect date format for last-made date. Make sure to enter date as DD/MM/YYYY.')
+        mock_cursor.execute.assert_not_called()
+        mock_connection.commit.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Milestone 1

This update finalizes a version of resippy that works solely with the SQL "menu" table in the resippy.db database. It can:

- Add new recipes to the menu, with additional ratings and 'last-made' date;
- Print out the whole menu into the console;
- Update existing recipe values with different ratings and last-made dates;
- Delete recipes from the menu

## Usage
usage: resippy.py [-h] [--drumlin_rating DRUMLIN_RATING] [--ian_rating IAN_RATING] [--lina_rating LINA_RATING]
                  [--last_made LAST_MADE] [--viewmenu]
                  [--new NEW | --update_menu UPDATE_MENU | --del_recipe DEL_RECIPE]

options:
  -h, --help            
show this help message and exit
  --drumlin_rating DRUMLIN_RATING
                        Drumlin's rating of the recipe
  --ian_rating IAN_RATING
                        ian's rating of the recipe
  --lina_rating LINA_RATING
                        Lina's rating of the recipe
  --last_made LAST_MADE
                        Date the recipe was last made (formatted as DD/MM/YYYY)
  --viewmenu            
View the menu (printed onto the console)
  --new NEW             
Add a new recipe. Include the name of the recipe you would like to add.
  --update_menu UPDATE_MENU
                        Update a recipe. Include the name of the recipe you would like to update.
  --del_recipe DEL_RECIPE
                        Delete a recipe. Include the name of the recipe you would like to delete.

## Next Steps
In the next milestone, I hope to:

- Update the viewmenu option such that I can also filter the menu based on ratings or last-made dates;
- Update the viewmenu option such that I can organize the rows by rating or by last_made dates;
- Limit the printed recipes to a certain number rather than printing the entire menu
- Add a "Dish Type" column to the menu table that includes options such as "Pasta", "Soup", "Salad", etc.
- Add a "Cuisine" column to the menu table that includes options such as "Mexican", "Thai", etc.